### PR TITLE
Expose calendar account/calendar IDs and surface category IDs

### DIFF
--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -44,6 +44,7 @@ Returns a list of events with their titles, times, and details.`,
           dateMin: startDate,
           dateMax: endDate,
           timezone: config.timezone,
+          include: "categories,calendar_account",
         });
 
         if (events.length === 0) {
@@ -71,6 +72,20 @@ Returns a list of events with their titles, times, and details.`,
             for (const [key, value] of Object.entries(attrs)) {
               if (value !== null && value !== undefined) {
                 parts.push(`  ${key}: ${value}`);
+              }
+            }
+
+            // Surface relationships (calendar_account, categories) — these are needed
+            // to construct create/update requests that route events to synced calendars
+            const rels = (event as unknown as { relationships?: Record<string, { data: unknown }> }).relationships;
+            if (rels) {
+              const acct = rels.calendar_account?.data as { id?: string } | null | undefined;
+              if (acct?.id) {
+                parts.push(`  calendar_account_id: ${acct.id}`);
+              }
+              const cats = rels.categories?.data as Array<{ id: string }> | undefined;
+              if (cats && cats.length > 0) {
+                parts.push(`  category_ids: [${cats.map((c) => c.id).join(", ")}]`);
               }
             }
 
@@ -186,10 +201,12 @@ Parameters:
 - description: Additional notes for the event
 - location: Where the event takes place
 - categoryIds: Family member IDs to associate with the event
+- calendarAccountId: Synced calendar account ID (from get_source_calendars). REQUIRED if you want the event to sync back to iCloud/Google. Without it, the event lives only on Skylight.
+- calendarId: Specific sub-calendar within the synced account (optional)
 
 Returns: The created event details.
 
-Related: Use get_family_members to get category IDs for assignments.`,
+Related: Use get_family_members to get category IDs for assignments, and get_source_calendars to get calendarAccountId values.`,
     {
       summary: z.string().describe("Event title (e.g., 'Dentist Appointment')"),
       startsAt: z.string().describe("Start time (ISO format like '2025-01-15T14:00:00')"),
@@ -198,8 +215,10 @@ Related: Use get_family_members to get category IDs for assignments.`,
       description: z.string().optional().describe("Additional notes for the event"),
       location: z.string().optional().describe("Event location"),
       categoryIds: z.array(z.string()).optional().describe("Family member IDs to assign"),
+      calendarAccountId: z.string().optional().describe("Synced calendar account ID (from get_source_calendars). Required for two-way sync back to iCloud/Google/Outlook."),
+      calendarId: z.string().optional().describe("Specific synced sub-calendar ID within the account (e.g. an iCloud sub-calendar). Optional; pairs with calendarAccountId."),
     },
-    async ({ summary, startsAt, endsAt, allDay, description, location, categoryIds }) => {
+    async ({ summary, startsAt, endsAt, allDay, description, location, categoryIds, calendarAccountId, calendarId }) => {
       try {
         const config = getConfig();
         const event = await createCalendarEvent({
@@ -210,6 +229,8 @@ Related: Use get_family_members to get category IDs for assignments.`,
           description,
           location,
           category_ids: categoryIds,
+          calendar_account_id: calendarAccountId,
+          calendar_id: calendarId,
           timezone: config.timezone,
           kind: "standard",
         });

--- a/src/tools/family.ts
+++ b/src/tools/family.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import { getFamilyMembers, getCategories } from "../api/endpoints/categories.js";
+import { getCategories } from "../api/endpoints/categories.js";
 import { getFrame } from "../api/endpoints/frames.js";
 import { getDevices } from "../api/endpoints/devices.js";
 import { formatErrorForMcp } from "../utils/errors.js";
@@ -9,61 +9,36 @@ export function registerFamilyTools(server: McpServer): void {
   // get_family_members tool
   server.tool(
     "get_family_members",
-    `Get family members/profiles from Skylight.
+    `Get all Skylight categories — family member profiles AND non-profile categories (like calendar groupings: "School", "Sports", etc.).
 
-Shows who can be assigned chores and their profile details.
+Shows who/what can be assigned to events and chores.
 
 Use this to answer:
 - "Who's in our family on Skylight?"
-- "What family members are set up?"
+- "What categories exist for tagging events?"
 - "Who can I assign chores to?"`,
     {},
     async () => {
       try {
-        const members = await getFamilyMembers();
+        const categories = await getCategories();
 
-        if (members.length === 0) {
-          // Fall back to all categories
-          const categories = await getCategories();
-          if (categories.length === 0) {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: "No family members or categories found in Skylight.",
-                },
-              ],
-            };
-          }
-
-          const categoryList = categories
-            .map((cat) => {
-              const parts = [`- ${cat.attributes.label ?? "Unnamed"}`];
-              if (cat.attributes.color) {
-                parts.push(`  Color: ${cat.attributes.color}`);
-              }
-              if (cat.attributes.selected_for_chore_chart) {
-                parts.push(`  On chore chart: Yes`);
-              }
-              return parts.join("\n");
-            })
-            .join("\n\n");
-
+        if (categories.length === 0) {
           return {
             content: [
               {
                 type: "text" as const,
-                text: `Categories (no linked profiles found):\n\n${categoryList}`,
+                text: "No categories found in Skylight.",
               },
             ],
           };
         }
 
-        const memberList = members
-          .map((member) => {
-            const attrs = member.attributes;
+        const categoryList = categories
+          .map((cat) => {
+            const attrs = cat.attributes;
             const parts = [`- ${attrs.label ?? "Unnamed"}`];
-
+            parts.push(`  ID: ${cat.id}`);
+            parts.push(`  Linked to profile: ${attrs.linked_to_profile ? "Yes" : "No"}`);
             if (attrs.color) {
               parts.push(`  Color: ${attrs.color}`);
             }
@@ -73,7 +48,6 @@ Use this to answer:
             if (attrs.selected_for_chore_chart) {
               parts.push(`  On chore chart: Yes`);
             }
-
             return parts.join("\n");
           })
           .join("\n\n");
@@ -82,7 +56,7 @@ Use this to answer:
           content: [
             {
               type: "text" as const,
-              text: `Family members:\n\n${memberList}`,
+              text: `Categories (profiles + non-profile categories):\n\n${categoryList}`,
             },
           ],
         };


### PR DESCRIPTION
## Summary

- **family.ts**: Simplified `get_family_members` to a single `getCategories()` call that returns all categories (profiles + non-profile like "School", "Sports") with their IDs and `linked_to_profile` flag
- **calendar.ts**: `get_calendar_events` now requests `include=categories,calendar_account` and surfaces `calendar_account_id` and `category_ids` from relationship data on each event
- **calendar.ts**: `create_calendar_event` accepts `calendarAccountId` and `calendarId` params for two-way sync back to iCloud/Google (the underlying API already supports these fields in `CreateCalendarEventRequest`)

## Motivation

Without these changes:
- Category/member IDs weren't visible, making it impossible to assign events or chores via the MCP tools
- Calendar events didn't show which synced calendar account they belonged to, so there was no way to create events that sync back to iCloud/Google
- The `get_family_members` tool only returned profile-linked categories, hiding non-profile categories used for calendar groupings

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] Verified `get_family_members` returns all categories with IDs via live API
- [x] Verified `get_source_calendars` returns calendar account IDs via live API