### PR TITLE
fix(calendar): normalize naked ISO datetimes; echo resolved fields on create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Calendar datetime timezone handling.** `create_calendar_event` and `update_calendar_event` no longer treat naked ISO datetimes (e.g. `"2026-05-28T19:45:00"`) as UTC. When the input has no timezone designator, the configured frame timezone's offset is appended before sending to the Skylight API. Existing callers passing ISO strings with `Z` or explicit `±HH:MM` offsets are unaffected.
+
+### Changed
+
+- **Calendar create/update return verbose confirmations.** `create_calendar_event` and `update_calendar_event` now echo the resolved fields (title, start, end, all-day, location) instead of just the event ID, mirroring `chores.js`. Lets callers verify what the server actually stored without a follow-up `get_calendar_events` call.
+
 ## [2.0.1] - 2026-04-19
 
 Docs + metadata only. No runtime code changes.

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -8,9 +8,32 @@ import {
   updateCalendarEvent,
   deleteCalendarEvent,
 } from "../api/endpoints/calendar.js";
-import { getTodayDate, parseDate, formatDateForDisplay } from "../utils/dates.js";
+import { getTodayDate, parseDate, formatDateForDisplay, normalizeDateTime } from "../utils/dates.js";
 import { formatErrorForMcp } from "../utils/errors.js";
 import { getConfig } from "../config.js";
+
+/**
+ * Render a multi-line confirmation message for a created or updated event.
+ * Echoes the resolved fields (including normalized datetimes) so callers can
+ * verify what the server actually stored without a follow-up read.
+ */
+function formatEventConfirmation(
+  verb: "Created" | "Updated",
+  event: { id: string; attributes?: Record<string, unknown> }
+): string {
+  const attrs = (event.attributes ?? {}) as Record<string, unknown>;
+  const lines = [`${verb} calendar event (ID: ${event.id})`];
+  const summary = attrs.summary as string | undefined;
+  if (summary) lines.push(`  Title: ${summary}`);
+  const startsAt = attrs.starts_at as string | undefined;
+  if (startsAt) lines.push(`  Starts: ${startsAt}`);
+  const endsAt = attrs.ends_at as string | undefined;
+  if (endsAt) lines.push(`  Ends: ${endsAt}`);
+  if (attrs.all_day === true) lines.push(`  All-day: yes`);
+  const location = attrs.location as string | undefined;
+  if (location) lines.push(`  Location: ${location}`);
+  return lines.join("\n");
+}
 
 export function registerCalendarTools(server: McpServer): void {
   // get_calendar_events tool
@@ -189,11 +212,24 @@ Parameters:
 
 Returns: The created event details.
 
+Notes:
+- Datetime values without a timezone designator (e.g. "2026-05-28T19:45:00")
+  are interpreted in the frame's configured timezone. Pass an explicit offset
+  (e.g. "...T19:45:00-07:00") to override.
+
 Related: Use get_family_members to get category IDs for assignments.`,
     {
       summary: z.string().describe("Event title (e.g., 'Dentist Appointment')"),
-      startsAt: z.string().describe("Start time (ISO format like '2025-01-15T14:00:00')"),
-      endsAt: z.string().describe("End time (ISO format like '2025-01-15T15:00:00')"),
+      startsAt: z
+        .string()
+        .describe(
+          "Start time (ISO format like '2025-01-15T14:00:00'; without an offset, interpreted in the frame timezone)"
+        ),
+      endsAt: z
+        .string()
+        .describe(
+          "End time (ISO format like '2025-01-15T15:00:00'; without an offset, interpreted in the frame timezone)"
+        ),
       allDay: z.boolean().optional().default(false).describe("True for all-day events"),
       description: z.string().optional().describe("Additional notes for the event"),
       location: z.string().optional().describe("Event location"),
@@ -204,8 +240,8 @@ Related: Use get_family_members to get category IDs for assignments.`,
         const config = getConfig();
         const event = await createCalendarEvent({
           summary,
-          starts_at: startsAt,
-          ends_at: endsAt,
+          starts_at: normalizeDateTime(startsAt, config.timezone),
+          ends_at: normalizeDateTime(endsAt, config.timezone),
           all_day: allDay,
           description,
           location,
@@ -218,7 +254,7 @@ Related: Use get_family_members to get category IDs for assignments.`,
           content: [
             {
               type: "text" as const,
-              text: `Created calendar event "${summary}" (ID: ${event.id})`,
+              text: formatEventConfirmation("Created", event),
             },
           ],
         };
@@ -250,12 +286,22 @@ Parameters:
 - location: Updated location
 - categoryIds: Updated family member assignments
 
-Returns: The updated event details.`,
+Returns: The updated event details.
+
+Notes:
+- Datetime values without a timezone designator are interpreted in the frame's
+  configured timezone. Pass an explicit offset to override.`,
     {
       eventId: z.string().describe("ID of the event to update"),
       summary: z.string().optional().describe("New event title"),
-      startsAt: z.string().optional().describe("New start time (ISO format)"),
-      endsAt: z.string().optional().describe("New end time (ISO format)"),
+      startsAt: z
+        .string()
+        .optional()
+        .describe("New start time (ISO format; without an offset, interpreted in the frame timezone)"),
+      endsAt: z
+        .string()
+        .optional()
+        .describe("New end time (ISO format; without an offset, interpreted in the frame timezone)"),
       allDay: z.boolean().optional().describe("Change to all-day event"),
       description: z.string().optional().describe("Updated notes"),
       location: z.string().optional().describe("Updated location"),
@@ -263,10 +309,11 @@ Returns: The updated event details.`,
     },
     async ({ eventId, summary, startsAt, endsAt, allDay, description, location, categoryIds }) => {
       try {
+        const config = getConfig();
         const updates: Record<string, unknown> = {};
         if (summary !== undefined) updates.summary = summary;
-        if (startsAt !== undefined) updates.starts_at = startsAt;
-        if (endsAt !== undefined) updates.ends_at = endsAt;
+        if (startsAt !== undefined) updates.starts_at = normalizeDateTime(startsAt, config.timezone);
+        if (endsAt !== undefined) updates.ends_at = normalizeDateTime(endsAt, config.timezone);
         if (allDay !== undefined) updates.all_day = allDay;
         if (description !== undefined) updates.description = description;
         if (location !== undefined) updates.location = location;
@@ -278,7 +325,7 @@ Returns: The updated event details.`,
           content: [
             {
               type: "text" as const,
-              text: `Updated calendar event (ID: ${event.id})`,
+              text: formatEventConfirmation("Updated", event),
             },
           ],
         };

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -119,3 +119,56 @@ export function formatDateForDisplay(dateStr: string): string {
     day: "numeric",
   });
 }
+
+/**
+ * Get the UTC offset (e.g. "-07:00", "+05:30") that applies to a given local
+ * date in a given IANA timezone. Accounts for DST.
+ */
+function getOffsetForDateInTimezone(localDateTime: string, timezone: string): string | null {
+  // Treat the naive local datetime as a UTC instant for the purpose of asking
+  // Intl what offset the target zone uses near that wall-clock moment. This is
+  // accurate for all dates except those within DST transition gaps/overlaps,
+  // which we accept as a documented edge case.
+  const refInstant = new Date(localDateTime.endsWith("Z") ? localDateTime : `${localDateTime}Z`);
+  if (isNaN(refInstant.getTime())) {
+    return null;
+  }
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    timeZoneName: "longOffset",
+    year: "numeric",
+  }).formatToParts(refInstant);
+  const tzName = parts.find((p) => p.type === "timeZoneName")?.value;
+  if (!tzName) return null;
+  // longOffset returns "GMT-07:00", "GMT+05:30", or bare "GMT" for UTC
+  if (tzName === "GMT") return "+00:00";
+  const match = tzName.match(/^GMT([+-]\d{2}:\d{2})$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Normalize a datetime string for the Skylight API.
+ *
+ * If `input` already has a timezone designator (trailing Z or ±HH:MM), it's
+ * returned unchanged. If it's a naive ISO datetime (e.g. "2026-05-28T19:45:00"),
+ * the offset for the configured frame timezone on that date is appended so the
+ * API doesn't interpret the wall-clock time as UTC.
+ *
+ * Returns the input unchanged if it doesn't look like an ISO datetime or if the
+ * timezone can't be resolved — letting the API surface its own validation error
+ * rather than us mangling the value.
+ */
+export function normalizeDateTime(input: string, timezone?: string): string {
+  if (!input) return input;
+  // Already has a timezone designator
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(input)) {
+    return input;
+  }
+  // Only normalize things that look like an ISO datetime "YYYY-MM-DDTHH:MM(:SS)?"
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(input)) {
+    return input;
+  }
+  if (!timezone) return input;
+  const offset = getOffsetForDateInTimezone(input, timezone);
+  return offset ? `${input}${offset}` : input;
+}

--- a/tests/dates.test.ts
+++ b/tests/dates.test.ts
@@ -5,6 +5,7 @@ import {
   parseDate,
   parseTime,
   formatDateForDisplay,
+  normalizeDateTime,
 } from "../src/utils/dates.js";
 
 describe("dates", () => {
@@ -137,6 +138,64 @@ describe("dates", () => {
     it("formats date for display", () => {
       expect(formatDateForDisplay("2025-06-15")).toMatch(/Sun.*Jun.*15/);
       expect(formatDateForDisplay("2025-12-25")).toMatch(/Thu.*Dec.*25/);
+    });
+  });
+
+  describe("normalizeDateTime", () => {
+    it("returns input unchanged when it has a trailing Z", () => {
+      expect(normalizeDateTime("2026-05-28T19:45:00Z", "America/Los_Angeles")).toBe(
+        "2026-05-28T19:45:00Z"
+      );
+    });
+
+    it("returns input unchanged when it has a numeric offset", () => {
+      expect(normalizeDateTime("2026-05-28T19:45:00-07:00", "America/Los_Angeles")).toBe(
+        "2026-05-28T19:45:00-07:00"
+      );
+      expect(normalizeDateTime("2026-05-28T19:45:00+05:30", "America/Los_Angeles")).toBe(
+        "2026-05-28T19:45:00+05:30"
+      );
+    });
+
+    it("appends the configured timezone offset for naive ISO datetimes (PDT)", () => {
+      // May 28 in LA is PDT (UTC-7)
+      expect(normalizeDateTime("2026-05-28T19:45:00", "America/Los_Angeles")).toBe(
+        "2026-05-28T19:45:00-07:00"
+      );
+    });
+
+    it("appends the correct offset across DST boundaries (PST)", () => {
+      // January in LA is PST (UTC-8)
+      expect(normalizeDateTime("2026-01-15T19:45:00", "America/Los_Angeles")).toBe(
+        "2026-01-15T19:45:00-08:00"
+      );
+    });
+
+    it("handles non-DST timezones", () => {
+      // Hawaii is UTC-10 year-round
+      expect(normalizeDateTime("2026-05-28T19:45:00", "Pacific/Honolulu")).toBe(
+        "2026-05-28T19:45:00-10:00"
+      );
+    });
+
+    it("handles positive offsets with half-hour fractions", () => {
+      // India is UTC+5:30
+      expect(normalizeDateTime("2026-05-28T19:45:00", "Asia/Kolkata")).toBe(
+        "2026-05-28T19:45:00+05:30"
+      );
+    });
+
+    it("returns input unchanged when no timezone is provided", () => {
+      expect(normalizeDateTime("2026-05-28T19:45:00")).toBe("2026-05-28T19:45:00");
+    });
+
+    it("returns input unchanged when it isn't an ISO datetime", () => {
+      expect(normalizeDateTime("not a datetime", "America/Los_Angeles")).toBe("not a datetime");
+      expect(normalizeDateTime("2026-05-28", "America/Los_Angeles")).toBe("2026-05-28");
+    });
+
+    it("handles empty string", () => {
+      expect(normalizeDateTime("", "America/Los_Angeles")).toBe("");
     });
   });
 });


### PR DESCRIPTION
Refs #6.

Opening as a draft to share the code without claiming review-queue time. Happy to mark ready for review, narrow further, or close if you'd rather see the work shaped differently — let me know.

## What this changes

Two of the three rough edges in #6 — both bringing `calendar.ts` in line with patterns already established in `chores.js`.

### 1. Datetime timezone handling

`create_calendar_event` and `update_calendar_event` previously passed `startsAt` / `endsAt` through to the API verbatim. A naked ISO string like `"2026-05-28T19:45:00"` was interpreted as UTC, landing on a Pacific-timezone frame at 12:45 PM instead of 7:45 PM. `config.timezone` was in scope but unused for this normalization.

New `normalizeDateTime(input, timezone)` helper in `src/utils/dates.ts`:
- Trailing `Z` or `±HH:MM` → returned unchanged (existing callers unaffected)
- Naive ISO datetime + configured timezone → offset for that date in that timezone is appended; DST respected via `Intl.DateTimeFormat` with `timeZoneName: "longOffset"`
- Date-only strings (e.g. `"2026-05-28"` for all-day events) → returned unchanged. The regex explicitly requires the `T<time>` portion, so only datetimes get normalized; all-day callers are not affected.
- Non-ISO input, or unresolvable timezone → returned unchanged so the API surfaces its own validation error rather than us mangling the value

Tool and parameter descriptions are updated to document this. 9 new tests cover trailing-Z and explicit-offset passthrough, PDT and PST across the DST boundary, non-DST timezones (Honolulu), fractional offsets (Kolkata, +05:30), missing-timezone passthrough, non-ISO and date-only passthrough, and empty-string handling.

### 2. Verbose confirmations on create/update

Previously `create_calendar_event` returned just `Created calendar event "..." (ID: ...)` and `update_calendar_event` returned `Updated calendar event (ID: ...)`. Without an echo, callers had no way to verify (for example) that the timezone normalization above produced the intended `starts_at` short of a follow-up `get_calendar_events` call.

A new `formatEventConfirmation()` helper in `src/tools/calendar.ts` renders verb + ID + title + starts_at + ends_at + all_day + location from the event's returned attributes. Both create and update use it. Mirrors `chores.js:222-238`.

## Not in this PR

Bug 1 from #6 (calendar tools exposing raw category IDs vs. accepting names like `chores.js`) overlaps with #3 and proposes a different solution than that issue's author. Holding that work until you've weighed in on which direction (or hybrid) you'd prefer.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 42/42 passing (was 33; +9 new tests for `normalizeDateTime`)
- `npm run build` — clean

## Disclosure

I'm a relatively new developer; my AI assistant helped me audit the source and shape the patch. Same as the project's own commits noting Claude Code co-authorship. The bug repro is from my own use.
