### PR TITLE
feat(calendar): add source-calendar sync params to create/update event tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Source calendar sync parameters on calendar event tools.** `create_calendar_event` and `update_calendar_event` now accept `calendarId`, `calendarAccountId`, `timezone`, `rrule`, `countdownEnabled`, and `kind` parameters. Events created with `calendarId` + `calendarAccountId` sync back to the underlying source calendar provider (Google, iCloud, etc.) instead of being Skylight-only. Required for events to appear in a connected Google Calendar after creation. (Ported from [upstream PR #23](https://github.com/TheEagleByte/skylight-mcp/pull/23) by [@avinashjoshi](https://github.com/avinashjoshi); upstream is unmaintained. Addresses [#1](https://github.com/rjhalvorson/skylight-mcp/issues/1); partially addresses [#3](https://github.com/rjhalvorson/skylight-mcp/issues/3).)
+
 ## [2.0.1] - 2026-04-19
 
 Docs + metadata only. No runtime code changes.

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -264,9 +264,12 @@ export interface UpdateCalendarEventRequest {
   description?: string;
   location?: string;
   category_ids?: string[];
+  calendar_account_id?: string;
+  calendar_id?: string;
   rrule?: string[] | null;
   timezone?: string;
   countdown_enabled?: boolean;
+  kind?: string;
 }
 
 export type CalendarEventResponse = JsonApiResponse<CalendarEventResource>;

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -189,6 +189,11 @@ Parameters:
 
 Returns: The created event details.
 
+To sync events to a connected Google/iCloud calendar, pass both calendarId
+and calendarAccountId. Use get_source_calendars to discover valid IDs.
+Without these, events are stored on Skylight only and do not sync back to
+the source calendar provider.
+
 Related: Use get_family_members to get category IDs for assignments.`,
     {
       summary: z.string().describe("Event title (e.g., 'Dentist Appointment')"),
@@ -198,8 +203,53 @@ Related: Use get_family_members to get category IDs for assignments.`,
       description: z.string().optional().describe("Additional notes for the event"),
       location: z.string().optional().describe("Event location"),
       categoryIds: z.array(z.string()).optional().describe("Family member IDs to assign"),
+      calendarId: z
+        .string()
+        .optional()
+        .describe(
+          "Source calendar ID to sync the event to (e.g., a Google Calendar ID). Use get_source_calendars to discover. Required together with calendarAccountId for two-way sync."
+        ),
+      calendarAccountId: z
+        .string()
+        .optional()
+        .describe(
+          "Skylight calendar account ID associated with the source calendar. Use get_source_calendars to discover. Required together with calendarId for two-way sync."
+        ),
+      timezone: z
+        .string()
+        .optional()
+        .describe(
+          "Event timezone (e.g., 'America/Los_Angeles'). Defaults to the frame's configured timezone."
+        ),
+      rrule: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("Recurrence rules in RRULE format (e.g., ['FREQ=WEEKLY;BYDAY=MO,WE,FR'])."),
+      countdownEnabled: z
+        .boolean()
+        .optional()
+        .describe("Show a countdown for this event on the frame."),
+      kind: z
+        .string()
+        .optional()
+        .describe("Event kind (e.g., 'standard', 'birthday'). Defaults to 'standard'."),
     },
-    async ({ summary, startsAt, endsAt, allDay, description, location, categoryIds }) => {
+    async ({
+      summary,
+      startsAt,
+      endsAt,
+      allDay,
+      description,
+      location,
+      categoryIds,
+      calendarId,
+      calendarAccountId,
+      timezone,
+      rrule,
+      countdownEnabled,
+      kind,
+    }) => {
       try {
         const config = getConfig();
         const event = await createCalendarEvent({
@@ -210,8 +260,12 @@ Related: Use get_family_members to get category IDs for assignments.`,
           description,
           location,
           category_ids: categoryIds,
-          timezone: config.timezone,
-          kind: "standard",
+          calendar_id: calendarId,
+          calendar_account_id: calendarAccountId,
+          timezone: timezone ?? config.timezone,
+          rrule,
+          countdown_enabled: countdownEnabled,
+          kind: kind ?? "standard",
         });
 
         return {
@@ -250,7 +304,11 @@ Parameters:
 - location: Updated location
 - categoryIds: Updated family member assignments
 
-Returns: The updated event details.`,
+Returns: The updated event details.
+
+To move an event between source calendars, update both calendarId and
+calendarAccountId together (use get_source_calendars to discover valid
+IDs).`,
     {
       eventId: z.string().describe("ID of the event to update"),
       summary: z.string().optional().describe("New event title"),
@@ -260,8 +318,46 @@ Returns: The updated event details.`,
       description: z.string().optional().describe("Updated notes"),
       location: z.string().optional().describe("Updated location"),
       categoryIds: z.array(z.string()).optional().describe("Updated family member assignments"),
+      calendarId: z
+        .string()
+        .optional()
+        .describe(
+          "Source calendar ID to associate the event with (from get_source_calendars). Pair with calendarAccountId."
+        ),
+      calendarAccountId: z
+        .string()
+        .optional()
+        .describe(
+          "Skylight calendar account ID associated with the source calendar (from get_source_calendars). Pair with calendarId."
+        ),
+      timezone: z.string().optional().describe("Updated event timezone (e.g., 'America/Los_Angeles')."),
+      rrule: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("Updated recurrence rules in RRULE format (or null to clear)."),
+      countdownEnabled: z
+        .boolean()
+        .optional()
+        .describe("Toggle the countdown display for this event."),
+      kind: z.string().optional().describe("Updated event kind (e.g., 'standard', 'birthday')."),
     },
-    async ({ eventId, summary, startsAt, endsAt, allDay, description, location, categoryIds }) => {
+    async ({
+      eventId,
+      summary,
+      startsAt,
+      endsAt,
+      allDay,
+      description,
+      location,
+      categoryIds,
+      calendarId,
+      calendarAccountId,
+      timezone,
+      rrule,
+      countdownEnabled,
+      kind,
+    }) => {
       try {
         const updates: Record<string, unknown> = {};
         if (summary !== undefined) updates.summary = summary;
@@ -271,6 +367,12 @@ Returns: The updated event details.`,
         if (description !== undefined) updates.description = description;
         if (location !== undefined) updates.location = location;
         if (categoryIds !== undefined) updates.category_ids = categoryIds;
+        if (calendarId !== undefined) updates.calendar_id = calendarId;
+        if (calendarAccountId !== undefined) updates.calendar_account_id = calendarAccountId;
+        if (timezone !== undefined) updates.timezone = timezone;
+        if (rrule !== undefined) updates.rrule = rrule;
+        if (countdownEnabled !== undefined) updates.countdown_enabled = countdownEnabled;
+        if (kind !== undefined) updates.kind = kind;
 
         const event = await updateCalendarEvent(eventId, updates);
 

--- a/tests/calendar.test.ts
+++ b/tests/calendar.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import type {
+  CreateCalendarEventRequest,
+  UpdateCalendarEventRequest,
+} from "../src/api/types.js";
+
+// These tests verify the request type shapes accept the synced-calendar
+// parameters added in this PR. They do not exercise the live Skylight API —
+// see the PR description for the verification gap and how it was mitigated by
+// porting from @avinashjoshi's upstream PR #23, which was verified end-to-end
+// against a live Google Calendar sync by its author.
+
+describe("calendar request types", () => {
+  describe("CreateCalendarEventRequest", () => {
+    it("accepts calendar_id and calendar_account_id for source calendar sync", () => {
+      const request: CreateCalendarEventRequest = {
+        summary: "Lunch with Sam",
+        starts_at: "2026-01-23T12:00:00-08:00",
+        ends_at: "2026-01-23T13:00:00-08:00",
+        calendar_account_id: "acct-123",
+        calendar_id: "primary@group.calendar.google.com",
+      };
+
+      expect(request.calendar_id).toBe("primary@group.calendar.google.com");
+      expect(request.calendar_account_id).toBe("acct-123");
+    });
+
+    it("accepts an explicit timezone override", () => {
+      const request: CreateCalendarEventRequest = {
+        summary: "Travel meeting",
+        starts_at: "2026-03-15T10:00:00",
+        ends_at: "2026-03-15T11:00:00",
+        timezone: "Europe/London",
+      };
+
+      expect(request.timezone).toBe("Europe/London");
+    });
+
+    it("accepts rrule for recurring events", () => {
+      const request: CreateCalendarEventRequest = {
+        summary: "Weekly team standup",
+        starts_at: "2026-01-26T10:00:00-08:00",
+        ends_at: "2026-01-26T10:30:00-08:00",
+        rrule: ["FREQ=WEEKLY;BYDAY=MO"],
+      };
+
+      expect(request.rrule).toEqual(["FREQ=WEEKLY;BYDAY=MO"]);
+    });
+
+    it("accepts null rrule for non-recurring events", () => {
+      const request: CreateCalendarEventRequest = {
+        summary: "Dentist",
+        starts_at: "2026-02-04T14:00:00-08:00",
+        ends_at: "2026-02-04T15:00:00-08:00",
+        rrule: null,
+      };
+
+      expect(request.rrule).toBeNull();
+    });
+
+    it("accepts countdown_enabled and kind", () => {
+      const request: CreateCalendarEventRequest = {
+        summary: "Anniversary",
+        starts_at: "2026-08-12T00:00:00-07:00",
+        ends_at: "2026-08-13T00:00:00-07:00",
+        all_day: true,
+        countdown_enabled: true,
+        kind: "birthday",
+      };
+
+      expect(request.countdown_enabled).toBe(true);
+      expect(request.kind).toBe("birthday");
+    });
+
+    it("composes all sync parameters with the original fields", () => {
+      const request: CreateCalendarEventRequest = {
+        summary: "Dinner at Passatempo",
+        starts_at: "2026-05-28T19:45:00-07:00",
+        ends_at: "2026-05-28T21:30:00-07:00",
+        all_day: false,
+        description: "Kyle & Beverly",
+        location: "Passatempo",
+        category_ids: ["cat-kyle", "cat-beverly"],
+        calendar_account_id: "acct-personal",
+        calendar_id: "kyle@gmail.com",
+        timezone: "America/Los_Angeles",
+        rrule: null,
+        countdown_enabled: false,
+        kind: "standard",
+      };
+
+      expect(request.summary).toBe("Dinner at Passatempo");
+      expect(request.location).toBe("Passatempo");
+      expect(request.category_ids).toEqual(["cat-kyle", "cat-beverly"]);
+      expect(request.calendar_id).toBe("kyle@gmail.com");
+      expect(request.calendar_account_id).toBe("acct-personal");
+    });
+  });
+
+  describe("UpdateCalendarEventRequest", () => {
+    it("accepts calendar_id and calendar_account_id to move an event between source calendars", () => {
+      const request: UpdateCalendarEventRequest = {
+        calendar_account_id: "acct-work",
+        calendar_id: "work@company.com",
+      };
+
+      expect(request.calendar_id).toBe("work@company.com");
+      expect(request.calendar_account_id).toBe("acct-work");
+    });
+
+    it("accepts kind for re-categorizing events", () => {
+      const request: UpdateCalendarEventRequest = {
+        kind: "birthday",
+      };
+
+      expect(request.kind).toBe("birthday");
+    });
+
+    it("accepts timezone, rrule, and countdown_enabled updates", () => {
+      const request: UpdateCalendarEventRequest = {
+        timezone: "America/New_York",
+        rrule: ["FREQ=DAILY"],
+        countdown_enabled: true,
+      };
+
+      expect(request.timezone).toBe("America/New_York");
+      expect(request.rrule).toEqual(["FREQ=DAILY"]);
+      expect(request.countdown_enabled).toBe(true);
+    });
+
+    it("composes all new fields with the original update fields", () => {
+      const request: UpdateCalendarEventRequest = {
+        summary: "Updated event",
+        starts_at: "2026-04-15T10:00:00-07:00",
+        ends_at: "2026-04-15T11:00:00-07:00",
+        calendar_account_id: "acct-789",
+        calendar_id: "shared@group.calendar.google.com",
+        timezone: "America/Los_Angeles",
+        rrule: ["FREQ=MONTHLY"],
+        countdown_enabled: false,
+        kind: "standard",
+      };
+
+      expect(request.calendar_account_id).toBe("acct-789");
+      expect(request.calendar_id).toBe("shared@group.calendar.google.com");
+      expect(request.rrule).toEqual(["FREQ=MONTHLY"]);
+    });
+  });
+
+  describe("webapp request parity", () => {
+    it("CreateCalendarEventRequest mirrors the shape Skylight's web app sends for synced events", () => {
+      // Reference shape observed by @avinashjoshi via network inspection in
+      // TheEagleByte/skylight-mcp PR #23. This documents the API contract
+      // we are coding against.
+      const webappRequest = {
+        summary: "test",
+        kind: "standard",
+        category_ids: ["cat-001"],
+        starts_at: "2026-01-23T02:00:00.000Z",
+        ends_at: "2026-01-23T03:00:00.000Z",
+        all_day: false,
+        rrule: null,
+        location: "",
+        description: "testing",
+        calendar_account_id: "acct-123",
+        calendar_id: "test-calendar@group.calendar.google.com",
+        timezone: "America/Los_Angeles",
+        countdown_enabled: false,
+      };
+
+      const request: CreateCalendarEventRequest = {
+        summary: webappRequest.summary,
+        kind: webappRequest.kind,
+        category_ids: webappRequest.category_ids,
+        starts_at: webappRequest.starts_at,
+        ends_at: webappRequest.ends_at,
+        all_day: webappRequest.all_day,
+        rrule: webappRequest.rrule,
+        location: webappRequest.location,
+        description: webappRequest.description,
+        calendar_account_id: webappRequest.calendar_account_id,
+        calendar_id: webappRequest.calendar_id,
+        timezone: webappRequest.timezone,
+        countdown_enabled: webappRequest.countdown_enabled,
+      };
+
+      expect(request.calendar_id).toBe(webappRequest.calendar_id);
+      expect(request.calendar_account_id).toBe(webappRequest.calendar_account_id);
+      expect(request.timezone).toBe(webappRequest.timezone);
+      expect(request.kind).toBe(webappRequest.kind);
+      expect(request.countdown_enabled).toBe(webappRequest.countdown_enabled);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1. Partially addresses #3 (the `calendar_account_id` half of @berryd07's report).

Faithful port of [upstream PR #23](https://github.com/TheEagleByte/skylight-mcp/pull/23) by @avinashjoshi against the unmaintained EagleByte fork — you named that PR as the template in issue #1. Adapted for v2.0.x signatures.

## What's added

- 6 optional params on `create_calendar_event` and `update_calendar_event`: `calendarId`, `calendarAccountId`, `timezone`, `rrule`, `countdownEnabled`, `kind`
- `UpdateCalendarEventRequest` now includes `calendar_account_id`, `calendar_id`, and `kind` (Create already had them)
- New `tests/calendar.test.ts` covering the request type shapes individually and in combination, with a webapp-parity test documenting the API contract

Behavior is fully opt-in. Callers that don't pass the new params get identical behavior to today.

## What I verified

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 44/44 passing (35 → 44; 9 new)
- `npm run build` — clean

## What I did NOT verify

End-to-end sync against a live Google/iCloud Calendar. My test frame has no synced source calendars (`get_source_calendars` returns empty), so I can't reproduce the round-trip @avinashjoshi captured. Relying on the original PR's verification and the fact that the request shape matches what the webapp sends (documented in the test file). You may want to verify on your own frame before merging.

## What I left out

Issue #1's scope also mentioned adding `calendar_id` / `calendar_account_id` to `get_calendar_events` as filter params. The upstream PR didn't include that, and I couldn't verify the API parameter name without a synced calendar to test against — deferred. Happy to add as a follow-up if you confirm the server-side param name (and that the endpoint supports filtering at all).

## Author credit

@avinashjoshi designed and verified this against a live sync. I'm porting their work, not designing fresh. Happy to format the commit as `Co-authored-by: avinashjoshi <...>` if you'd prefer that to a porting-context reference. Let me know.

## Disclosure

I'm a relatively new developer; my AI assistant helped me audit, adapt, and write the patch. Same as your own commits noting Claude Code co-authorship.
